### PR TITLE
Specify Dolphin and Primehack save locations and add BigPEmu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,18 @@
 # ludusavi-emudeck-manifest
 Additional [Ludusavi](https://github.com/mtkennerly/ludusavi) manifest for finding save location of emulators based on information on the [emudeck wiki.](https://emudeck.github.io/save-management/steamos/save-management/)
 
-## How To Us:
+## How To Use:
 
 ### 1. Add manifest to Ludusavi
 
 You can add the manifest in the "other" tab and adding the new manifest to the list.
 
-Link to add: https://raw.githubusercontent.com/hblamo/ludusavi-emudeck-manifest/main/manifest.yml
-
-
+Link to add: https://raw.githubusercontent.com/pwatk/ludusavi-emudeck-manifest/main/manifest.yml
 
 ### 2. Update roots (if needed)
 
-If you've installed Emudeck on a seperate drive (or SD card), you'll want to make sure that drive is configured as a "home folder" in Ludusavi. I just duplicated my SD card location. So I had 2, one configured as a steam drive and one configured as a home folder.
-
+If the Emulation folder is on an SD card you will need to add the path (e.g. /run/media/deck/sdcard) as a new "Home folder" [root](https://github.com/mtkennerly/ludusavi/blob/master/docs/help/roots.md) in Ludusavi.
 
 ## Known issues:
 
-Windows is not setup to work. If anyone is interested in this, just setup a PR and we can figure it out together.
+Incompatible with Windows.

--- a/manifest.yml
+++ b/manifest.yml
@@ -135,7 +135,7 @@
         - os: linux
 "PrimeHack":
   files:
-    "<home>/.var/app/io.github.shiiion.primehack/data/dolphin-emu/Wii":
+    "<home>/.var/app/io.github.shiiion.primehack/data/dolphin-emu/Wii/title":
       tags:
         - save
       when:

--- a/manifest.yml
+++ b/manifest.yml
@@ -100,12 +100,12 @@
         - os: linux
 "Flycast (Emudeck)":
   files:
-    "<home>.var/app/org.flycast.Flycast/data/flycast/*.*":
+    "<home>/.var/app/org.flycast.Flycast/data/flycast/*.*":
       tags:
         - save
       when:
         - os: linux
-    "<home>.var/app/org.flycast.Flycast/config/data/flycast":
+    "<home>/.var/app/org.flycast.Flycast/config/data/flycast":
       tags:
         - save
       when:

--- a/manifest.yml
+++ b/manifest.yml
@@ -76,6 +76,11 @@
         - save-states
       when:
         - os: linux
+    "<home>/.var/app/org.DolphinEmu.dolphin-emu/data/dolphin-emu/Load/Riivolution":
+      tags:
+        - config
+      when:
+        - os: linux
 "DuckStation":
   files:
     "<home>/Emulation/saves/duckstation/saves":
@@ -153,6 +158,11 @@
     "<home>/.var/app/org.ppsspp.PPSSPP/config/ppsspp/PSP/PPSSPP_STATE":
       tags:
         - save-states
+      when:
+        - os: linux
+    "<home>/.var/app/org.ppsspp.PPSSPP/config/ppsspp/PSP/Cheats":
+      tags:
+        - config
       when:
         - os: linux
 "PrimeHack":

--- a/manifest.yml
+++ b/manifest.yml
@@ -39,7 +39,12 @@
         - os: linux
 "Dolphin":
   files:
-    "<home>/.var/app/org.DolphinEmu.dolphin-emu/data/dolphin-emu":
+    "<home>/.var/app/org.DolphinEmu.dolphin-emu/data/dolphin-emu/Wii/title":
+      tags:
+        - save
+      when:
+        - os: linux
+    "<home>/.var/app/org.DolphinEmu.dolphin-emu/data/dolphin-emu/GC":
       tags:
         - save
       when:

--- a/manifest.yml
+++ b/manifest.yml
@@ -105,7 +105,6 @@
         - save
       when:
         - os: linux
-  files:
     "<home>.var/app/org.flycast.Flycast/config/data/flycast":
       tags:
         - save

--- a/manifest.yml
+++ b/manifest.yml
@@ -11,6 +11,28 @@
         - save-states
       when:
         - os: linux
+"BigPEmu":
+  files:
+    "<home>/.bigpemu_userdata/*.bigpeep":
+      tags:
+        - save
+      when:
+        - os: linux
+    "<home>/.bigpemu_userdata/*.bigpstate":
+      tags:
+        - save-states
+      when:
+        - os: linux
+    "<home>/Applications/BigPEmu/UserData/*.bigpeep":
+      tags:
+        - save
+      when:
+        - os: linux
+    "<home>/Applications/BigPEmu/UserData/*.bigpstate":
+      tags:
+        - save-states
+      when:
+        - os: linux
 "Cemu":
   files:
     "<home>/Emulation/roms/wiiu/mlc01/usr/save":

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,5 @@
 ---
-"Azahar":
+"Azahar (Emudeck)":
   files:
     "<home>/Emulation/storage/azahar/sdmc":
       tags:
@@ -8,10 +8,10 @@
         - os: linux
     "<home>/.local/share/azahar-emu/states":
       tags:
-        - save-states
+        - save
       when:
         - os: linux
-"BigPEmu":
+"BigPEmu (Emudeck)":
   files:
     "<home>/.bigpemu_userdata/*.bigpeep":
       tags:
@@ -20,7 +20,7 @@
         - os: linux
     "<home>/.bigpemu_userdata/*.bigpstate":
       tags:
-        - save-states
+        - save
       when:
         - os: linux
     "<home>/Applications/BigPEmu/UserData/*.bigpeep":
@@ -30,36 +30,24 @@
         - os: linux
     "<home>/Applications/BigPEmu/UserData/*.bigpstate":
       tags:
-        - save-states
+        - save
       when:
         - os: linux
-"Cemu":
+"Cemu (Emudeck)":
   files:
     "<home>/Emulation/roms/wiiu/mlc01/usr/save":
       tags:
         - save
       when:
         - os: linux
-"Citra":
-  files:
-    "<home>/.var/app/org.citra_emu.citra/data/citra-emu/sdmc":
-      tags:
-        - save
-      when:
-        - os: linux
-    "<home>/.var/app/org.citra_emu.citra/data/citra-emu/states":
-      tags:
-        - save-states
-      when:
-        - os: linux
-"Citron":
+"Citron (Emudeck)":
   files:
     "<home>/Emulation/storage/citron/nand/user/save/":
       tags:
         - save
       when:
         - os: linux
-"Dolphin":
+"Dolphin (Emudeck)":
   files:
     "<home>/.var/app/org.DolphinEmu.dolphin-emu/data/dolphin-emu/Wii/title":
       tags:
@@ -73,7 +61,7 @@
         - os: linux
     "<home>/.var/app/org.DolphinEmu.dolphin-emu/data/dolphin-emu/StateSaves":
       tags:
-        - save-states
+        - save
       when:
         - os: linux
     "<home>/.var/app/org.DolphinEmu.dolphin-emu/data/dolphin-emu/Load/Riivolution":
@@ -81,7 +69,17 @@
         - config
       when:
         - os: linux
-"DuckStation":
+    "<home>/.var/app/org.DolphinEmu.dolphin-emu/data/dolphin-emu/GameSettings":
+      tags:
+        - config
+      when:
+        - os: linux
+    "<home>/.var/app/org.DolphinEmu.dolphin-emu/config/dolphin-emu/Profiles":
+      tags:
+        - config
+      when:
+        - os: linux
+"DuckStation (Emudeck)":
   files:
     "<home>/Emulation/saves/duckstation/saves":
       tags:
@@ -90,17 +88,30 @@
         - os: linux
     "<home>/Emulation/saves/duckstation/states":
       tags:
-        - save-states
+        - save
       when:
         - os: linux
-"Eden":
+"Eden (Emudeck)":
   files:
     "<home>/Emulation/storage/eden/nand/user/save/":
       tags:
         - save
       when:
         - os: linux
-"MAME":
+"Flycast (Emudeck)":
+  files:
+    "<home>.var/app/org.flycast.Flycast/data/flycast/*.*":
+      tags:
+        - save
+      when:
+        - os: linux
+  files:
+    "<home>.var/app/org.flycast.Flycast/config/data/flycast":
+      tags:
+        - save
+      when:
+        - os: linux
+"MAME (Emudeck)":
   files:
     "<home>/Emulation/saves/MAME/saves":
       tags:
@@ -109,10 +120,10 @@
         - os: linux
     "<home>/Emulation/saves/MAME/states":
       tags:
-        - save-states
+        - save
       when:
         - os: linux
-"melonDS":
+"melonDS (Emudeck)":
   files:
     "<home>/Emulation/saves/melonds/saves":
       tags:
@@ -121,10 +132,10 @@
         - os: linux
     "<home>/Emulation/saves/melonds/states":
       tags:
-        - save-states
+        - save
       when:
         - os: linux
-"mGBA":
+"mGBA (Emudeck)":
   files:
     "<home>/Emulation/saves/mgba/saves":
       tags:
@@ -133,10 +144,10 @@
         - os: linux
     "<home>/Emulation/saves/mgba/states":
       tags:
-        - save-states
+        - save
       when:
         - os: linux
-"PCSX2":
+"PCSX2 (Emudeck)":
   files:
     "<home>/Emulation/saves/pcsx2/saves":
       tags:
@@ -145,10 +156,10 @@
         - os: linux
     "<home>/Emulation/saves/pcsx2/states":
       tags:
-        - save-states
+        - save
       when:
         - os: linux
-"PPSSPP":
+"PPSSPP (Emudeck)":
   files:
     "<home>/.var/app/org.ppsspp.PPSSPP/config/ppsspp/PSP/SAVEDATA":
       tags:
@@ -157,7 +168,7 @@
         - os: linux
     "<home>/.var/app/org.ppsspp.PPSSPP/config/ppsspp/PSP/PPSSPP_STATE":
       tags:
-        - save-states
+        - save
       when:
         - os: linux
     "<home>/.var/app/org.ppsspp.PPSSPP/config/ppsspp/PSP/Cheats":
@@ -165,7 +176,7 @@
         - config
       when:
         - os: linux
-"PrimeHack":
+"PrimeHack (Emudeck)":
   files:
     "<home>/.var/app/io.github.shiiion.primehack/data/dolphin-emu/Wii/title":
       tags:
@@ -174,10 +185,10 @@
         - os: linux
     "<home>/.var/app/io.github.shiiion.primehack/data/dolphin-emu/StateSaves":
       tags:
-        - save-states
+        - save
       when:
         - os: linux
-"RetroArch":
+"RetroArch (Emudeck)":
   files:
     "<home>/.var/app/org.libretro.RetroArch/config/retroarch/saves":
       tags:
@@ -186,10 +197,10 @@
         - os: linux
     "<home>/.var/app/org.libretro.RetroArch/config/retroarch/states":
       tags:
-        - save-states
+        - save
       when:
         - os: linux
-"Rosalie's Mupen GUI":
+"Rosalie's Mupen GUI (Emudeck)":
   files:
     "<home>/Emulation/saves/RMG/saves":
       tags:
@@ -198,17 +209,17 @@
         - os: linux
     "<home>/Emulation/saves/RMG/states":
       tags:
-        - save-states
+        - save
       when:
         - os: linux
-"RPCS3":
+"RPCS3 (Emudeck)":
   files:
     "<home>/Emulation/storage/rpcs3/dev_hdd0/home/00000001/savedata":
       tags:
         - save
       when:
         - os: linux
-"Ryujinx":
+"Ryujinx (Emudeck)":
   files:
     "<home>/.config/Ryujinx/bis/user/save":
       tags:
@@ -220,35 +231,48 @@
         - save-meta
       when:
         - os: linux
-"ScummVM":
+"ScummVM (Emudeck)":
   files:
     "<home>/Emulation/saves/scummvm/saves":
       tags:
         - save
       when:
         - os: linux
-"Vita3K":
+"shadPS4 (Emudeck)":
+  files:
+    "<home>/.local/share/shadPS4/savedata":
+      tags:
+        - save
+      when:
+        - os: linux
+"Vita3K (Emudeck)":
   files:
     "<home>/Emulation/storage/Vita3K/ux0/user/00/savedata":
       tags:
         - save
       when:
         - os: linux
-"Xemu":
+"Xemu (Emudeck)":
   files:
-    "<home>/Emulation/storage/xemu":
+    "<home>/Emulation/storage/xemu/xbox_hdd.qcow2":
       tags:
         - save
       when:
         - os: linux
-"Xenia":
+  files:
+    "<home>/Emulation/storage/xemu/eeprom.bin":
+      tags:
+        - save
+      when:
+        - os: linux
+"Xenia (Emudeck)":
   files:
     "<home>/Emulation/roms/xbox360/content":
       tags:
         - save
       when:
         - os: linux
-"Yuzu":
+"Yuzu (Emudeck)":
   files:
     "<home>/Emulation/storage/yuzu/nand/user/save/":
       tags:

--- a/manifest.yml
+++ b/manifest.yml
@@ -258,7 +258,6 @@
         - save
       when:
         - os: linux
-  files:
     "<home>/Emulation/storage/xemu/eeprom.bin":
       tags:
         - save


### PR DESCRIPTION
This change reduces the amount of additional data being backed up for Dolphin and Primehack and adds support for BigPEmu.